### PR TITLE
Fix Transformer correctness issues

### DIFF
--- a/src/layers/multiHeadAttention.ts
+++ b/src/layers/multiHeadAttention.ts
@@ -123,13 +123,14 @@ export default class MultiHeadAttention {
 
   compile({ alpha, optimizer, error, clipGradient }: { alpha?: number; optimizer?: Optimzier; error?: Cost; clipGradient?: number | boolean }) {
     if (alpha !== undefined) this.alpha = alpha;
+    if (clipGradient !== undefined) this.clipGradient = clipGradient;
     if (optimizer !== undefined) {
       this.optimizerName = optimizer;
       this.optimizerQ = setOptimizer(optimizer, this.q._shape, this.alpha);
       this.optimizerK = setOptimizer(optimizer, this.k._shape, this.alpha);
       this.optimizerV = setOptimizer(optimizer, this.v._shape, this.alpha);
     }
-    this.wo.compile({ alpha, optimizer, error });
+    this.wo.compile({ alpha, optimizer, error, clipGradient });
   }
 
   setPadMask(padMask: boolean[]): void {

--- a/src/layers/positionalEncoding.ts
+++ b/src/layers/positionalEncoding.ts
@@ -80,8 +80,9 @@ export default class PositionalEncoding {
    *   retain their original absolute positions in the PE table.
    * @param seqLen - actual per-batch sequence length used for cycling column indices to
    *   positions within a sequence.  Defaults to maxSeqLen (original behavior).
+   * @param padMask - optional sample-major mask where true means the whole token column is PAD.
    */
-  forward(x: Matrix, positionOffset = 0, seqLen?: number): Matrix {
+  forward(x: Matrix, positionOffset = 0, seqLen?: number, padMask?: boolean[]): Matrix {
     const actualTotalTokens = x._shape[1];
     const cycleLen = seqLen ?? this.maxSeqLen;
     this.inputShape = [this.dModel, actualTotalTokens];
@@ -113,7 +114,7 @@ export default class PositionalEncoding {
           );
         }
         const val = xData[xOffset + j];
-        result[outOffset + j] = val === 0 ? 0 : val + peData[peOffset + absolutePos];
+        result[outOffset + j] = padMask?.[j] === true ? 0 : val + peData[peOffset + absolutePos];
       }
     }
 

--- a/src/layers/positionalEncoding.ts
+++ b/src/layers/positionalEncoding.ts
@@ -27,6 +27,7 @@ export default class PositionalEncoding {
   // Tabel PE yang sudah diprecompute: [dModel, maxSeqLen]
   private peTable: Matrix;
   private resultBuffer: Matrix | null = null;
+  private inferredPadMask: boolean[] = [];
 
   constructor({
     dModel,
@@ -99,6 +100,7 @@ export default class PositionalEncoding {
     const xData = x._data;
     const peData = this.peTable._data;
     const peCols = this.peTable._shape[1];
+    const effectivePadMask = padMask ?? this.inferPadColumns(x);
 
     for (let i = 0; i < this.dModel; i++) {
       const xOffset = i * cols;
@@ -114,7 +116,7 @@ export default class PositionalEncoding {
           );
         }
         const val = xData[xOffset + j];
-        result[outOffset + j] = padMask?.[j] === true ? 0 : val + peData[peOffset + absolutePos];
+        result[outOffset + j] = effectivePadMask[j] ? 0 : val + peData[peOffset + absolutePos];
       }
     }
 
@@ -130,5 +132,25 @@ export default class PositionalEncoding {
 
   resetLoss(): void {
     this.loss = 0;
+  }
+
+  private inferPadColumns(x: Matrix): boolean[] {
+    const [rows, cols] = x._shape;
+    if (this.inferredPadMask.length !== cols) {
+      this.inferredPadMask = new Array<boolean>(cols);
+    }
+    this.inferredPadMask.fill(true);
+
+    const data = x._data;
+    for (let j = 0; j < cols; j++) {
+      for (let i = 0; i < rows; i++) {
+        if (data[i * cols + j] !== 0) {
+          this.inferredPadMask[j] = false;
+          break;
+        }
+      }
+    }
+
+    return this.inferredPadMask;
   }
 }

--- a/src/models/sequential.ts
+++ b/src/models/sequential.ts
@@ -360,7 +360,13 @@ export default class Sequential {
         modelAny.setPositionOffset(trimResult.positionOffset);
       }
 
-      const pred = this.forward(valBatchX);
+      const shouldUseFullSequenceForward =
+        valBatchY._shape[0] === valBatchX._shape[0] &&
+        valBatchY._shape[1] === valBatchX._shape[1] &&
+        typeof modelAny.forwardFullSequence === "function";
+      const pred = shouldUseFullSequenceForward
+        ? modelAny.forwardFullSequence(valBatchX)
+        : this.forward(valBatchX);
       totalValLoss += this.computeSampleLoss(valBatchY, pred);
 
       if (supportsTrimPadding && typeof modelAny.resetPositionOffset === "function") {


### PR DESCRIPTION
## Summary

Fixes Transformer correctness issues found in the static review:

- Validation now uses `forwardFullSequence()` when validating full-sequence targets on models that expose it, so Transformer validation loss is computed from `[vocabSize, seqLen * batch]` logits instead of last-token logits.
- `PositionalEncoding` now applies PAD handling per token column instead of checking each embedding dimension with `val === 0`, preventing non-PAD zero-valued embedding dimensions from incorrectly skipping positional encoding.
- `MultiHeadAttention.compile()` now applies `clipGradient` to Q/K/V gradients and passes it through to the internal output projection layer.

## Notes

I could not run the repository test suite from the execution container because direct network access to GitHub was unavailable there, so this PR is based on connector-backed code edits and static verification of the diff.