### PR TITLE
Validate Embedding token IDs before native path

### DIFF
--- a/src/layers/embedding.ts
+++ b/src/layers/embedding.ts
@@ -209,6 +209,7 @@ export default class Embedding {
       }
     }
     this.inputIndices = this.orderedInputBuffer;
+    this.validateTokenIndices(totalTokens);
 
     const seqLen = totalTokens;
     this.inputShape = [rows, cols];
@@ -230,9 +231,6 @@ export default class Embedding {
 
     for (let j = 0; j < seqLen; j++) {
       const tokenIndex = Math.floor(this.inputIndices[j]);
-      if (tokenIndex < 0 || tokenIndex >= this.vocabSize) {
-        throw new Error(`Token index '${tokenIndex}' di luar kapasitas vocabulary (0 - ${this.vocabSize - 1})`);
-      }
       if (this.padTokenId !== null && tokenIndex === this.padTokenId) {
         continue;
       }
@@ -242,5 +240,15 @@ export default class Embedding {
     }
 
     return this.outputBuffer;
+  }
+
+  private validateTokenIndices(seqLen: number): void {
+    for (let j = 0; j < seqLen; j++) {
+      const rawTokenIndex = this.inputIndices[j];
+      const tokenIndex = Math.floor(rawTokenIndex);
+      if (!Number.isFinite(rawTokenIndex) || tokenIndex < 0 || tokenIndex >= this.vocabSize) {
+        throw new Error(`Token index '${rawTokenIndex}' di luar kapasitas vocabulary (0 - ${this.vocabSize - 1})`);
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds TypeScript-side validation for `Embedding` token IDs before dispatching to the native Rust embedding forward path.

## Why

The JS fallback currently throws when a token index is negative or outside the vocabulary range. The native Rust path silently skips invalid token IDs and leaves those embeddings as zeros. That makes behavior depend on whether native is enabled and can hide data/preprocessing bugs during training.

## Change

- Centralizes token ID validation in `Embedding.forwardWithLayout()`.
- Runs validation before either JS fallback or native forward.
- Keeps the JS fallback inner loop simpler because invalid IDs have already been checked.

## Notes

I could not run the repository test suite from the container because it cannot resolve github.com for cloning/installing dependencies, so this patch is based on connector-backed static review.