### PR TITLE
Fix Transformer correctness and validate embedding token IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ ML-V1 adalah library low-level sampai mid-level untuk eksperimen dan pengembanga
 - Menggabungkan kemudahan TypeScript dengan performa Rust untuk hot paths.
 
 ## Versioning
-Versi aktif proyek saat ini adalah `2.2.2`.
+Versi aktif proyek saat ini adalah `2.2.3`.
 
-Proyek ini memakai format versi `MAJOR.MINOR.PATCH` seperti `2.2.2`.
+Proyek ini memakai format versi `MAJOR.MINOR.PATCH` seperti `2.2.3`.
 
 - Angka paling depan (`MAJOR`): perubahan besar yang biasanya membawa breaking change atau perubahan arsitektur utama.
 - Angka tengah (`MINOR`): penambahan fitur baru atau peningkatan yang tetap kompatibel dengan versi sebelumnya.
@@ -21,6 +21,7 @@ Proyek ini memakai format versi `MAJOR.MINOR.PATCH` seperti `2.2.2`.
 
 Contoh:
 - `2.2.0`: rilis mayor `2`, minor `2`, dynamic padding trim + positional encoding offset.
+- `2.2.3`: patch untuk optimasi hot path training/inference, refresh benchmark family model, dan correctness learning snapshot terbaru.
 - `2.2.2`: patch untuk suite gabungan root, benchmark family model, dan correctness learning snapshot.
 - `2.0.2`: rilis mayor `2`, minor `0`, patch `2` untuk optimasi projector transformer tanpa perubahan API.
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ ML-V1 adalah library low-level sampai mid-level untuk eksperimen dan pengembanga
 - Menggabungkan kemudahan TypeScript dengan performa Rust untuk hot paths.
 
 ## Versioning
-Versi aktif proyek saat ini adalah `2.2.3`.
+Versi aktif proyek saat ini adalah `2.2.4`.
 
-Proyek ini memakai format versi `MAJOR.MINOR.PATCH` seperti `2.2.3`.
+Proyek ini memakai format versi `MAJOR.MINOR.PATCH` seperti `2.2.4`.
 
 - Angka paling depan (`MAJOR`): perubahan besar yang biasanya membawa breaking change atau perubahan arsitektur utama.
 - Angka tengah (`MINOR`): penambahan fitur baru atau peningkatan yang tetap kompatibel dengan versi sebelumnya.
@@ -21,6 +21,7 @@ Proyek ini memakai format versi `MAJOR.MINOR.PATCH` seperti `2.2.3`.
 
 Contoh:
 - `2.2.0`: rilis mayor `2`, minor `2`, dynamic padding trim + positional encoding offset.
+- `2.2.4`: patch untuk ergonomi API `Transformers.predictMode`, sinkronisasi docs, dan refactor correctness suite.
 - `2.2.3`: patch untuk optimasi hot path training/inference, refresh benchmark family model, dan correctness learning snapshot terbaru.
 - `2.2.2`: patch untuk suite gabungan root, benchmark family model, dan correctness learning snapshot.
 - `2.0.2`: rilis mayor `2`, minor `0`, patch `2` untuk optimasi projector transformer tanpa perubahan API.
@@ -175,17 +176,26 @@ console.log("shape", logits._shape, "loss", model.loss);
 import mj from "./src/math";
 import { Transformers } from "./src/models";
 
-const model = new Transformers({ units: 64, seqLen: 8, vocabSize: 500, heads: 8, alpha: 0.001, padTokenId: 0 });
+const model = new Transformers({
+  units: 64,
+  seqLen: 8,
+  vocabSize: 500,
+  heads: 8,
+  alpha: 0.001,
+  padTokenId: 0,
+  predictMode: "next-token",
+});
 model.eval();
 
 const x = mj.matrix([[0], [0], [10], [20], [30], [40], [50], [60]]);
 const nextTokenLogits = model.predict(x); // [vocabSize, batch]
-// setara dengan model.forwardNextToken(x)
+model.setPredictMode("full-sequence");
+const fullSequenceLogits = model.predict(x); // [vocabSize, seqLen * batch]
 ```
 
 ## Models overview
 - `Sequential`: stack layer umum (dense/embedding/attention/cnn).
-- `Transformers`: model transformer bertingkat dengan `numBlocks >= 1`, training full-sequence causal LM, dan inference last-token.
+- `Transformers`: model transformer bertingkat dengan `numBlocks >= 1`, training full-sequence causal LM, dan inference configurable via `predictMode`.
 - `DimentionalityReduction`: turunan `Sequential` dengan pemisahan encoder/decoder via status layer `outputReduction`.
 
 ## Layers overview
@@ -216,6 +226,7 @@ const nextTokenLogits = model.predict(x); // [vocabSize, batch]
 1. Muat model/tokenizer.
 2. Ubah input ke token/matrix.
 3. `predict()` atau `forward()`.
+   Untuk `Transformers`, `predict()` mengikuti `predictMode`.
 4. Ambil argmax/logit sesuai kebutuhan task.
 5. Decode token ke teks (jika NLP).
 
@@ -279,7 +290,8 @@ model.fit(trainX, trainY, 80, {
 - Konsistenkan `seqLen` antara preprocessing dan model constructor.
 - Tetapkan `padTokenId` di tokenizer + model embedding.
 - Untuk `Transformers`, siapkan target shifted next-token dengan shape `[seqLen, batch]` dan isi posisi yang tidak valid dengan `padTokenId`.
-- Gunakan `model.train()` untuk training full-sequence dan `model.predict()` / `model.forwardNextToken()` untuk inferensi generatif berbasis last-token.
+- Gunakan `model.train()` untuk training full-sequence.
+- Untuk inferensi transformer, gunakan `model.predict()` sebagai entry point utama dan atur `predictMode` ke `"next-token"` atau `"full-sequence"` sesuai kebutuhan.
 - Untuk recurrent `stateful`, hindari `shuffle=true` dan `validationSplit > 0` di loop `Sequential.fit()` generic saat ini.
 - Awali debug dengan `ML_DISABLE_NATIVE=1` saat membandingkan perilaku JS vs native.
 - Cek shape di setiap boundary layer bila loss tidak turun.

--- a/docs/GUIDE-LINE/03-tutorial.md
+++ b/docs/GUIDE-LINE/03-tutorial.md
@@ -142,9 +142,9 @@ model.backward(y);
 
 ## 6. Full-Sequence Causal LM dengan Transformers
 
-Untuk `Transformers`, jalur training dan inference sengaja dipisahkan:
+Untuk `Transformers`, jalur training dan inference tetap dipisahkan, tetapi inference sekarang bisa disatukan lewat `predictMode`:
 - training: logits untuk seluruh posisi token valid
-- inference: logits token terakhir saja untuk sampling token berikutnya
+- inference: default logits token terakhir, atau full-sequence jika diminta
 
 ```ts
 import mj from "./src/math";
@@ -158,6 +158,7 @@ const model = new Transformers({
   heads: 4,
   alpha: 0.001,
   padTokenId,
+  predictMode: "next-token",
 });
 
 const x = mj.matrix([
@@ -184,13 +185,17 @@ model.backward(y);
 
 model.eval();
 const nextTokenLogits = model.predict(x); // [vocabSize, batch]
+
+model.setPredictMode("full-sequence");
+const allTokenLogits = model.predict(x); // [vocabSize, seqLen * batch]
 ```
 
 ---
 
 ## Tips Pengembangan
 
-- **Mode Training vs Evol**: Gunakan `model.train()` saat melatih dan `model.eval()` saat melakukan inferensi (terutama jika menggunakan layer `Dropout`).
+- **Mode Training vs Eval**: Gunakan `model.train()` saat melatih dan `model.eval()` saat melakukan inferensi (terutama jika menggunakan layer `Dropout`).
+- **Mode Predict Transformer**: Gunakan `predictMode: "next-token"` untuk generation loop, atau `predictMode: "full-sequence"` bila ingin inspeksi logits semua posisi lewat method `predict()` yang sama.
 - **Dimensi Matriks**: Selalu periksa shape matriks Anda. Sebagian besar layer mengharapkan input dalam bentuk `[features, batch_size]` atau `[sequence_length, batch_size]`.
 
 ---

--- a/docs/GUIDE-LINE/04-api-functions.md
+++ b/docs/GUIDE-LINE/04-api-functions.md
@@ -673,7 +673,7 @@ Model arsitektur Transformer yang lengkap (berbasis arsitektur `Sequential`) unt
 
 Perubahan penting pada versi ini:
 - training path sekarang memakai **full-sequence causal LM**
-- inference path tetap memakai **last-token logits**
+- inference path default tetap memakai **last-token logits**, tetapi `predict()` kini bisa diubah ke full-sequence
 - arsitektur sekarang mendukung **multi-block depth** lewat `numBlocks`
 - target training yang benar adalah **shifted next-token targets** dengan shape `[seqLen, batch]`
 - kontrak lama `backward(y)` dengan target `[1, batch]` masih diterima sebagai compatibility path terbatas, tetapi bukan lagi path training yang direkomendasikan
@@ -682,7 +682,9 @@ Perubahan penting pada versi ini:
 
 - **Input token IDs**: `Matrix` dengan shape `[seqLen, batch]`
 - **Training logits** (`model.train(); model.forward(x)` atau `model.forwardFullSequence(x)`): `[vocabSize, seqLen * batch]`
-- **Inference logits** (`model.eval(); model.forward(x)`, `model.forwardNextToken(x)`, atau `model.predict(x)`): `[vocabSize, batch]`
+- **Inference logits**
+  - `model.eval(); model.forward(x)` atau `model.forwardNextToken(x)`: `[vocabSize, batch]`
+  - `model.predict(x)`: mengikuti `predictMode`
 - **Training target**: `Matrix` sparse index `[seqLen, batch]`
 - **Legacy target**: `Matrix` sparse index `[1, batch]`
 
@@ -706,6 +708,7 @@ Posisi valid untuk loss full-sequence:
 - **`alpha`**: Learning rate (default: 0.01).
 - **`padTokenId`**: Token padding yang harus diabaikan di embedding, attention pad mask, dan loss full-sequence.
 - **`clipGradient`**: Batas clipping gradien global untuk seluruh sub-layer (default: 5.0).
+- **`predictMode`**: Mode output default untuk `predict()`. Pilihan: `"next-token"` (default) atau `"full-sequence"`.
 
 ```ts
 import { Transformers } from "./src/models";
@@ -717,7 +720,8 @@ const model = new Transformers({
   heads: 8,
   numBlocks: 4,
   padTokenId: 0,
-  clipGradient: 1.5
+  clipGradient: 1.5,
+  predictMode: "next-token",
 });
 ```
 
@@ -757,7 +761,24 @@ Gunakan untuk sampling token berikutnya pada loop generation, atau untuk loop tr
 
 #### `predict(input)`
 
-`predict()` sekarang memakai jalur inference last-token dan mengembalikan shape `[vocabSize, batch]`.
+`predict()` sekarang menjadi entry point inference tunggal, dan shape output-nya mengikuti `predictMode` pada constructor:
+
+- `predictMode: "next-token"` -> logits `[vocabSize, batch]`
+- `predictMode: "full-sequence"` -> logits `[vocabSize, seqLen * batch]`
+
+Default tetap `"next-token"` agar kompatibel dengan generation loop yang lama.
+
+#### `setPredictMode(mode)` / `getPredictMode()`
+
+Gunakan ini jika ingin mengganti mode `predict()` tanpa membuat instance baru.
+
+```ts
+model.setPredictMode("full-sequence");
+const logitsAll = model.predict(x); // [vocabSize, seqLen * batch]
+
+model.setPredictMode("next-token");
+const nextLogits = model.predict(x); // [vocabSize, batch]
+```
 
 #### `backward(target)`
 
@@ -854,6 +875,7 @@ const model = new Transformers({
   numBlocks: 2,
   alpha: 0.001,
   padTokenId: 0,
+  predictMode: "next-token",
 });
 
 model.eval();
@@ -867,6 +889,35 @@ const x = mj.matrix([
 ]);
 
 const nextTokenLogits = model.predict(x); // [vocabSize, 1]
+```
+
+#### Contoh Inference Full-Sequence via `predict()`
+
+```ts
+import mj from "./src/math";
+import { Transformers } from "./src/models";
+
+const model = new Transformers({
+  units: 64,
+  seqLen: 6,
+  vocabSize: 2000,
+  heads: 8,
+  numBlocks: 2,
+  alpha: 0.001,
+  padTokenId: 0,
+  predictMode: "full-sequence",
+});
+
+const x = mj.matrix([
+  [0],
+  [11],
+  [12],
+  [13],
+  [14],
+  [15],
+]);
+
+const logits = model.predict(x); // [vocabSize, seqLen]
 ```
 
 #### Contoh Legacy Next-Token Training
@@ -908,8 +959,9 @@ console.log(logits._shape, model.loss);
 - Konsistenkan `seqLen`, `vocabSize`, dan `padTokenId` antara tokenizer, preprocessing, dan model.
 - Mulai dari `numBlocks=2` atau `numBlocks=4` jika ingin model lebih dalam, lalu benchmark karena biaya runtime akan naik signifikan.
 - Pastikan posisi pad di target tetap `padTokenId` agar loss tidak menghitung area padding.
-- Gunakan `model.predict()` atau `model.forwardNextToken()` pada generation loop agar sampling tetap memakai last-token logits.
+- Gunakan `predictMode: "next-token"` lalu `model.predict()` pada generation loop agar sampling tetap memakai last-token logits.
 - Gunakan `model.forwardFullSequence()` bila Anda butuh inspeksi logits semua posisi saat eval/debug.
+- Jika ingin menyatukan API inference ke satu method, gunakan `predict()` + `predictMode` dan anggap `forwardNextToken()` / `forwardFullSequence()` sebagai method eksplisit tingkat lanjut.
 - Aktifkan `trimPadding: true` (default) di `fit()` untuk performa optimal saat data memiliki banyak padding.
 
 #### Dynamic Padding Trim
@@ -1014,7 +1066,7 @@ Sesudah refactor:
 - training default memakai objective full-sequence causal LM
 - shape output `forward()` saat mode train berubah dari `[vocabSize, batch]` menjadi `[vocabSize, seqLen * batch]`
 - `backward()` idealnya menerima target shifted `[seqLen, batch]`
-- jalur inference last-token dipertahankan lewat `predict()` dan `forwardNextToken()`
+- jalur inference last-token dipertahankan lewat `forwardNextToken()` dan lewat `predict()` saat `predictMode="next-token"`
 - compatibility path last-token training juga tetap tersedia melalui `forwardNextToken()` saat model berada di mode train
 - arsitektur kini dapat ditingkatkan kedalamannya dengan `numBlocks` tanpa mengubah API training/inference utama
 - `trimPadding: true` (default) aktif untuk Transformers dan mengurangi biaya komputasi pada batch dengan banyak padding

--- a/docs/benchmark-sintetis/README.md
+++ b/docs/benchmark-sintetis/README.md
@@ -103,6 +103,7 @@ Catatan:
 | [v2.2.1](./v2.2.1.md) | 2026-04-24 | `24f4d55` + local patch | Optimasi reuse buffer pada keluarga recurrent dan snapshot benchmark micro untuk `rnn`/`transformers` |
 | [v2.2.2](./v2.2.2.md) | 2026-04-24 | `7a0728f` + local patch | Suite gabungan root, benchmark family recurrent/transformer, dan snapshot correctness learning terbaru |
 | [v2.2.3](./v2.2.3.md) | 2026-04-25 | `ac0806c` + local patch | Optimasi hot path training/inference dan refresh benchmark family model setelah patch performa terbaru |
+| [v2.2.4](./v2.2.4.md) | 2026-04-25 | `397ed48` + local patch | Ergonomi API `predictMode`, sinkronisasi docs, refactor correctness suite, dan refresh snapshot benchmark |
 
 ## Cara Menambah Versi Baru
 
@@ -121,9 +122,9 @@ Catatan:
 - Snapshot recurrent lama sebelum `v1.2.3` masih berguna sebagai referensi historis, tetapi tidak lagi fair untuk membandingkan throughput recurrent karena jalur benchmark utamanya masih memproses sample satu per satu di dalam batch efektif.
 
 ## Versioning
-Versi aktif proyek saat ini adalah `2.2.3`.
+Versi aktif proyek saat ini adalah `2.2.4`.
 
-Proyek ini memakai format versi `MAJOR.MINOR.PATCH` seperti `2.2.3`.
+Proyek ini memakai format versi `MAJOR.MINOR.PATCH` seperti `2.2.4`.
 
 - Angka paling depan (`MAJOR`): perubahan besar yang biasanya membawa breaking change atau perubahan arsitektur utama.
 - Angka tengah (`MINOR`): penambahan fitur baru atau peningkatan yang tetap kompatibel dengan versi sebelumnya.
@@ -133,3 +134,4 @@ Contoh:
 - `2.2.0`: rilis minor `2` untuk fitur dynamic padding (`trimPadding`) dan proyek `math-reasoning-ai`.
 - `2.2.2`: patch untuk suite gabungan root, benchmark family model, dan correctness learning snapshot.
 - `2.2.3`: patch untuk optimasi hot path training/inference dan snapshot benchmark/correctness terbaru.
+- `2.2.4`: patch untuk ergonomi API `predictMode`, sinkronisasi docs, dan refactor correctness suite.

--- a/docs/benchmark-sintetis/README.md
+++ b/docs/benchmark-sintetis/README.md
@@ -102,6 +102,7 @@ Catatan:
 | [v2.2.0](./v2.2.0.md) | 2026-04-24 | `fa33aa0` + local patch | Fitur dynamic padding (`trimPadding`), proyek `math-reasoning-ai`, dan benchmark baseline v2.2.0 |
 | [v2.2.1](./v2.2.1.md) | 2026-04-24 | `24f4d55` + local patch | Optimasi reuse buffer pada keluarga recurrent dan snapshot benchmark micro untuk `rnn`/`transformers` |
 | [v2.2.2](./v2.2.2.md) | 2026-04-24 | `7a0728f` + local patch | Suite gabungan root, benchmark family recurrent/transformer, dan snapshot correctness learning terbaru |
+| [v2.2.3](./v2.2.3.md) | 2026-04-25 | `ac0806c` + local patch | Optimasi hot path training/inference dan refresh benchmark family model setelah patch performa terbaru |
 
 ## Cara Menambah Versi Baru
 
@@ -120,9 +121,9 @@ Catatan:
 - Snapshot recurrent lama sebelum `v1.2.3` masih berguna sebagai referensi historis, tetapi tidak lagi fair untuk membandingkan throughput recurrent karena jalur benchmark utamanya masih memproses sample satu per satu di dalam batch efektif.
 
 ## Versioning
-Versi aktif proyek saat ini adalah `2.2.2`.
+Versi aktif proyek saat ini adalah `2.2.3`.
 
-Proyek ini memakai format versi `MAJOR.MINOR.PATCH` seperti `2.2.2`.
+Proyek ini memakai format versi `MAJOR.MINOR.PATCH` seperti `2.2.3`.
 
 - Angka paling depan (`MAJOR`): perubahan besar yang biasanya membawa breaking change atau perubahan arsitektur utama.
 - Angka tengah (`MINOR`): penambahan fitur baru atau peningkatan yang tetap kompatibel dengan versi sebelumnya.
@@ -131,3 +132,4 @@ Proyek ini memakai format versi `MAJOR.MINOR.PATCH` seperti `2.2.2`.
 Contoh:
 - `2.2.0`: rilis minor `2` untuk fitur dynamic padding (`trimPadding`) dan proyek `math-reasoning-ai`.
 - `2.2.2`: patch untuk suite gabungan root, benchmark family model, dan correctness learning snapshot.
+- `2.2.3`: patch untuk optimasi hot path training/inference dan snapshot benchmark/correctness terbaru.

--- a/docs/benchmark-sintetis/v2.2.3.md
+++ b/docs/benchmark-sintetis/v2.2.3.md
@@ -1,0 +1,157 @@
+# Benchmark Sintetis `v2.2.3`
+
+## Metadata
+
+- Tanggal: 25 April 2026
+- Versi: `2.2.3`
+- Commit: `ac0806c` + local patch
+- Tujuan snapshot: Mendokumentasikan hasil benchmark setelah optimasi hot path pada `Sequential.fit()`, jalur loss transformer full-sequence, reuse buffer `MultiHeadAttention`, dan `AdaGrad`.
+
+## Environment
+
+- OS: `Linux (CachyOS)`
+- Kernel: `6.19.10-1-cachyos`
+- Arsitektur: `x86_64`
+- CPU: `11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz`
+- Core / Thread: `4 core / 8 thread`
+- RAM: `~15.4 GiB`
+- Swap: `~15.4 GiB`
+- npm: `11.12.1`
+- Rust: `rustc 1.94.1 (e408947bf 2026-03-25)`
+- Runtime Node.js: `v25.8.2`
+- Backend native aktif: `Ya`
+- Catatan hardware: Snapshot ini diambil dari output `npm test` pada mesin yang sama dengan baseline `v2.2.2`, sehingga perbandingan antar versi masih cukup fair untuk benchmark sintetis ini.
+
+## Training Data
+
+- Dataset path: tidak memakai file dataset eksternal
+- Sumber data: synthetic in-memory benchmark fixtures
+- Jumlah record raw: `N/A`
+- Jumlah record valid: `RNN=128 sample`, `Transformers=96 sample`
+- Ukuran file dataset: `N/A`
+- Ukuran corpus efektif: `N/A`
+- Ukuran tokenized corpus: `N/A`
+- Subset yang dipakai benchmark:
+  - `RNN family`: `128` sample, `seqLen=24`, `units=16`, `hiddenUnits=32`, `classes=6`
+  - `Transformers`: `96` sample, `seqLen=24`, `vocabSize=128`, `units=32`, `heads=4`, `numBlocks=2`, `batchSize=8`
+- Catatan preprocessing: benchmark transformer tetap memakai fixture synthetic yang sama dengan `v2.2.2`, termasuk pasangan mode `full-token-padded-no-trim` dan `full-token-trimPad` agar tetap apple-to-apple.
+
+## Correctness Companion
+
+- Command: `npm test`
+- Correctness command mandiri: `node -r ts-node/register test/correctness/index.ts`
+- Status: `pass`
+- Cakupan singkat:
+  - learning test 10 epoch untuk `RNN`, `LSTM`, `GRU`
+  - learning test 10 epoch untuk transformer `full-token`
+  - learning test 10 epoch untuk transformer `full-token-trimPad`
+  - learning test 10 epoch untuk transformer `next-token` legacy path
+
+## Daftar Benchmark
+
+| Nama | File | Command | Status |
+| --- | --- | --- | --- |
+| `family_rnn_training` | `test/benchmark/testFamilyRnn.test.ts` | `node -r ts-node/register test/benchmark/testFamilyRnn.test.ts` | success |
+| `transformer_modes` | `test/benchmark/testFamilyTransformers.test.ts` | `node -r ts-node/register test/benchmark/testFamilyTransformers.test.ts` | success |
+| `suite_gabungan` | `test/index.ts` | `npm test` | success |
+
+## Hasil
+
+### 1. `family_rnn_training`
+
+- Status: `success`
+- Konfigurasi:
+  - `epochs=3`
+  - `samples=128`
+  - `seqLen=24`
+  - `units=16`
+  - `hiddenUnits=32`
+  - `numClasses=6`
+
+| Model | Total ms | Avg Epoch ms | Samples/s | Final Loss |
+| --- | ---: | ---: | ---: | ---: |
+| `rnn` | `109.25` | `36.42` | `3515.02` | `0.694696` |
+| `lstm` | `321.87` | `107.29` | `1193.05` | `0.704413` |
+| `gru` | `260.20` | `86.73` | `1475.77` | `0.706218` |
+
+- Output ringkas:
+  - `rnn`: epoch ms `38.59, 34.86, 35.78` | epoch loss `1.004330, 0.722883, 0.694696`
+  - `lstm`: epoch ms `107.79, 108.87, 105.20` | epoch loss `1.000612, 0.719958, 0.704413`
+  - `gru`: epoch ms `87.59, 86.75, 85.85` | epoch loss `1.049475, 0.721163, 0.706218`
+
+### 2. `transformer_modes`
+
+- Status: `success`
+- Konfigurasi:
+  - `epochs=3`
+  - `samples=96`
+  - `seqLen=24`
+  - `vocabSize=128`
+  - `units=32`
+  - `heads=4`
+  - `numBlocks=2`
+  - `batchSize=8`
+
+| Mode | Total ms | Avg Epoch ms | Samples/s | Final Loss |
+| --- | ---: | ---: | ---: | ---: |
+| `full-token` | `131.88` | `43.96` | `2183.74` | `4.759616` |
+| `full-token-padded-no-trim` | `114.12` | `38.04` | `2523.75` | `4.798110` |
+| `full-token-trimPad` | `126.69` | `42.23` | `2273.23` | `4.798251` |
+| `next-token` | `125.73` | `41.91` | `2290.69` | `4.840612` |
+
+- Output ringkas:
+  - `full-token`: epoch ms `44.04, 46.04, 41.79` | epoch loss `5.017969, 4.848075, 4.759616`
+  - `full-token-padded-no-trim`: epoch ms `39.08, 37.13, 37.89` | epoch loss `5.095249, 4.884421, 4.798110`
+  - `full-token-trimPad`: epoch ms `38.00, 57.85, 30.81` | epoch loss `5.110431, 4.882927, 4.798251`
+  - `next-token`: epoch ms `34.64, 58.00, 33.07` | epoch loss `5.116356, 4.923863, 4.840612`
+
+### 3. `suite_gabungan`
+
+- Status: `success`
+- Ukuran data training: correctness suite + benchmark suite pada satu entry point root
+- Metrik utama: verifikasi bahwa `npm test` masih menjalankan correctness lalu benchmark berurutan tanpa error setelah optimasi hot path
+- Output ringkas:
+  - correctness recurrent `pass`
+  - correctness transformer `pass`
+  - benchmark recurrent family `success`
+  - benchmark transformer modes `success`
+
+## Benchmark Gagal
+
+- Tidak ada benchmark gagal pada snapshot ini.
+
+## Perubahan Penting Dibanding Versi Sebelumnya (`v2.2.2`)
+
+- `Sequential.fit()` kini memakai reusable batch buffer dan menghitung trim window sebelum copy batch multi-sample.
+- Training transformer full-sequence tidak lagi menghitung softmax/loss terpisah sebelum `backward()`.
+- `MultiHeadAttention` kini memakai growth-capacity untuk buffer sequence utama sehingga tidak realloc penuh setiap perubahan `totalCols`.
+- `AdaGrad` diubah ke loop in-place tunggal dengan update buffer reusable.
+
+## Interpretasi
+
+- Jalur transformer full-sequence membaik tipis sampai moderat dibanding `v2.2.2`, terutama pada mode `trimPad`.
+- `full-token`: `2154.11 -> 2183.74 samples/s` (`+1.4%`)
+- `full-token-padded-no-trim`: `2415.81 -> 2523.75 samples/s` (`+4.5%`)
+- `full-token-trimPad`: `2165.09 -> 2273.23 samples/s` (`+5.0%`)
+- `next-token` justru turun dari `2879.82 -> 2290.69 samples/s` (`-20.5%`), sehingga masih ada regresi yang perlu diinvestigasi terpisah dari jalur full-sequence.
+- Pada keluarga recurrent, `rnn` dan `lstm` naik tipis, sementara `gru` turun tipis; perubahan patch ini memang tidak menarget jalur recurrent.
+
+## Tindak Lanjut
+
+- Audit regresi `transformer next-token` secara khusus karena penurunan throughput cukup besar dibanding `v2.2.2`.
+- Tambahkan benchmark trim padding dengan `seqLen` lebih panjang dan distribusi sequence yang lebih variatif agar efek trimming lebih stabil.
+- Pertahankan `npm test` sebagai command snapshot resmi agar correctness dan benchmark tetap comparable.
+
+## Versioning
+Versi aktif proyek saat ini adalah `2.2.3`.
+
+Proyek ini memakai format versi `MAJOR.MINOR.PATCH` seperti `2.2.3`.
+
+- Angka paling depan (`MAJOR`): perubahan besar yang biasanya membawa breaking change atau perubahan arsitektur utama.
+- Angka tengah (`MINOR`): penambahan fitur baru atau peningkatan yang tetap kompatibel dengan versi sebelumnya.
+- Angka paling belakang (`PATCH`): perbaikan bug, optimasi kecil, cleanup, atau perubahan minor yang tidak mengubah API utama.
+
+Contoh:
+- `2.2.0`: rilis minor `2` untuk fitur dynamic padding (`trimPadding`) dan proyek `math-reasoning-ai`.
+- `2.2.2`: patch untuk suite gabungan root, benchmark family model, dan correctness learning suite.
+- `2.2.3`: patch untuk optimasi hot path training/inference dan refresh snapshot benchmark/correctness.

--- a/docs/benchmark-sintetis/v2.2.4.md
+++ b/docs/benchmark-sintetis/v2.2.4.md
@@ -1,0 +1,155 @@
+# Benchmark Sintetis `v2.2.4`
+
+## Metadata
+
+- Tanggal: 25 April 2026
+- Versi: `2.2.4`
+- Commit: `397ed48` + local patch
+- Tujuan snapshot: Mendokumentasikan hasil benchmark setelah penambahan `predictMode` pada `Transformers`, sinkronisasi dokumentasi inference API, dan pemisahan correctness suite API vs learning.
+
+## Environment
+
+- OS: `Linux (CachyOS)`
+- Kernel: `6.19.10-1-cachyos`
+- Arsitektur: `x86_64`
+- CPU: `11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz`
+- Core / Thread: `4 core / 8 thread`
+- RAM: `~15.4 GiB`
+- Swap: `~15.4 GiB`
+- npm: `11.12.1`
+- Rust: `rustc 1.94.1 (e408947bf 2026-03-25)`
+- Runtime Node.js: `v25.8.2`
+- Backend native aktif: `Ya`
+- Catatan hardware: Snapshot ini diambil dari `npm test` pada mesin yang sama dengan snapshot `v2.2.3`, tetapi benchmark mikro tetap memiliki variasi run-to-run yang terlihat cukup nyata pada workload transformer dan recurrent.
+
+## Training Data
+
+- Dataset path: tidak memakai file dataset eksternal
+- Sumber data: synthetic in-memory benchmark fixtures
+- Jumlah record raw: `N/A`
+- Jumlah record valid: `RNN=128 sample`, `Transformers=96 sample`
+- Ukuran file dataset: `N/A`
+- Ukuran corpus efektif: `N/A`
+- Ukuran tokenized corpus: `N/A`
+- Subset yang dipakai benchmark:
+  - `RNN family`: `128` sample, `seqLen=24`, `units=16`, `hiddenUnits=32`, `classes=6`
+  - `Transformers`: `96` sample, `seqLen=24`, `vocabSize=128`, `units=32`, `heads=4`, `numBlocks=2`, `batchSize=8`
+- Catatan preprocessing: benchmark transformer tetap memakai fixture synthetic yang sama dengan `v2.2.2` dan `v2.2.3`, termasuk pasangan mode `full-token-padded-no-trim` dan `full-token-trimPad`.
+
+## Correctness Companion
+
+- Command: `npm test`
+- Correctness command mandiri: `node -r ts-node/register test/correctness/index.ts`
+- Status: `pass`
+- Cakupan singkat:
+  - learning test 10 epoch untuk `RNN`, `LSTM`, `GRU`
+  - correctness API untuk `Transformers.predictMode`
+  - learning test 10 epoch untuk transformer `full-token`
+  - learning test 10 epoch untuk transformer `full-token-trimPad`
+  - learning test 10 epoch untuk transformer `next-token` legacy path
+
+## Daftar Benchmark
+
+| Nama | File | Command | Status |
+| --- | --- | --- | --- |
+| `family_rnn_training` | `test/benchmark/testFamilyRnn.test.ts` | `node -r ts-node/register test/benchmark/testFamilyRnn.test.ts` | success |
+| `transformer_modes` | `test/benchmark/testFamilyTransformers.test.ts` | `node -r ts-node/register test/benchmark/testFamilyTransformers.test.ts` | success |
+| `suite_gabungan` | `test/index.ts` | `npm test` | success |
+
+## Hasil
+
+### 1. `family_rnn_training`
+
+- Status: `success`
+- Konfigurasi:
+  - `epochs=3`
+  - `samples=128`
+  - `seqLen=24`
+  - `units=16`
+  - `hiddenUnits=32`
+  - `numClasses=6`
+
+| Model | Total ms | Avg Epoch ms | Samples/s | Final Loss |
+| --- | ---: | ---: | ---: | ---: |
+| `rnn` | `113.73` | `37.91` | `3376.49` | `0.702019` |
+| `lstm` | `470.07` | `156.69` | `816.90` | `0.703162` |
+| `gru` | `273.88` | `91.29` | `1402.05` | `0.693604` |
+
+- Output ringkas:
+  - `rnn`: epoch ms `40.19, 37.15, 36.38` | epoch loss `1.066231, 0.727386, 0.702019`
+  - `lstm`: epoch ms `124.61, 215.54, 129.91` | epoch loss `1.074591, 0.721381, 0.703162`
+  - `gru`: epoch ms `97.13, 89.56, 87.19` | epoch loss `0.865381, 0.706926, 0.693604`
+
+### 2. `transformer_modes`
+
+- Status: `success`
+- Konfigurasi:
+  - `epochs=3`
+  - `samples=96`
+  - `seqLen=24`
+  - `vocabSize=128`
+  - `units=32`
+  - `heads=4`
+  - `numBlocks=2`
+  - `batchSize=8`
+
+| Mode | Total ms | Avg Epoch ms | Samples/s | Final Loss |
+| --- | ---: | ---: | ---: | ---: |
+| `full-token` | `179.51` | `59.84` | `1604.39` | `4.768150` |
+| `full-token-padded-no-trim` | `124.79` | `41.60` | `2307.88` | `4.768287` |
+| `full-token-trimPad` | `163.50` | `54.50` | `1761.51` | `4.788294` |
+| `next-token` | `104.82` | `34.94` | `2747.67` | `4.920780` |
+
+- Output ringkas:
+  - `full-token`: epoch ms `64.90, 66.29, 48.30` | epoch loss `4.994404, 4.863523, 4.768150`
+  - `full-token-padded-no-trim`: epoch ms `41.55, 43.20, 40.03` | epoch loss `5.030366, 4.852604, 4.768287`
+  - `full-token-trimPad`: epoch ms `43.42, 87.19, 32.87` | epoch loss `5.062523, 4.884041, 4.788294`
+  - `next-token`: epoch ms `34.12, 36.01, 34.67` | epoch loss `5.157113, 4.992143, 4.920780`
+
+### 3. `suite_gabungan`
+
+- Status: `success`
+- Ukuran data training: correctness suite + benchmark suite pada satu entry point root
+- Metrik utama: verifikasi bahwa `npm test` tetap menjalankan correctness API, correctness learning, dan benchmark secara berurutan tanpa error
+- Output ringkas:
+  - correctness recurrent `pass`
+  - correctness transformer API `pass`
+  - correctness transformer learning `pass`
+  - benchmark recurrent family `success`
+  - benchmark transformer modes `success`
+
+## Benchmark Gagal
+
+- Tidak ada benchmark gagal pada snapshot ini.
+
+## Perubahan Penting Dibanding Versi Sebelumnya (`v2.2.3`)
+
+- Ditambahkan `predictMode` pada constructor `Transformers` untuk menyatukan entry point inference lewat `predict()`.
+- Ditambahkan `setPredictMode()` dan `getPredictMode()` untuk mengganti mode inference tanpa membuat instance baru.
+- Dokumentasi `README` dan `GUIDE-LINE` diperbarui agar `predict()` tidak lagi diasumsikan selalu last-token.
+- Correctness suite transformer dipecah menjadi API correctness dan learning correctness.
+
+## Interpretasi
+
+- Patch `v2.2.4` tidak menargetkan performa langsung; fokus utamanya adalah ergonomi API dan kerapian suite test.
+- Angka benchmark pada snapshot ini menunjukkan variasi run-to-run yang cukup besar, sehingga tidak tepat diperlakukan sebagai bukti peningkatan atau regresi performa final dibanding `v2.2.3`.
+- `next-token` pada run ini pulih mendekati baseline sebelumnya, tetapi `full-token` dan recurrent masih berfluktuasi. Ini mengindikasikan benchmark sintetis saat ini sensitif terhadap noise runtime mesin lokal.
+
+## Tindak Lanjut
+
+- Jika benchmark akan dipakai untuk keputusan performa antar patch, jalankan beberapa kali lalu simpan rata-rata/median, bukan satu snapshot tunggal.
+- Tambahkan benchmark inference eksplisit untuk `predictMode="full-sequence"` vs `predictMode="next-token"` bila API inference baru ingin dipantau khusus.
+- Pertahankan pemisahan correctness API vs learning karena struktur ini lebih mudah dipelihara.
+
+## Versioning
+Versi aktif proyek saat ini adalah `2.2.4`.
+
+Proyek ini memakai format versi `MAJOR.MINOR.PATCH` seperti `2.2.4`.
+
+- Angka paling depan (`MAJOR`): perubahan besar yang biasanya membawa breaking change atau perubahan arsitektur utama.
+- Angka tengah (`MINOR`): penambahan fitur baru atau peningkatan yang tetap kompatibel dengan versi sebelumnya.
+- Angka paling belakang (`PATCH`): perbaikan bug, optimasi kecil, cleanup, atau perubahan minor yang tidak mengubah API utama.
+
+Contoh:
+- `2.2.3`: patch untuk optimasi hot path training/inference dan refresh snapshot benchmark/correctness.
+- `2.2.4`: patch untuk ergonomi API `predictMode`, sinkronisasi docs, dan refactor correctness suite.

--- a/docs/correctness/README.md
+++ b/docs/correctness/README.md
@@ -41,12 +41,13 @@ npm test
 | --- | --- | --- | --- |
 | [v2.2.2](./v2.2.2.md) | 2026-04-24 | `7a0728f` + local patch | Snapshot correctness learning suite untuk recurrent dan transformer, termasuk `trimPad` |
 | [v2.2.3](./v2.2.3.md) | 2026-04-25 | `ac0806c` + local patch | Snapshot correctness setelah optimasi batching/loss/buffer pada hot path training |
+| [v2.2.4](./v2.2.4.md) | 2026-04-25 | `397ed48` + local patch | Snapshot correctness setelah penambahan `predictMode` dan pemisahan suite API vs learning |
 
 ## Versioning
 
-Versi aktif proyek saat ini adalah `2.2.3`.
+Versi aktif proyek saat ini adalah `2.2.4`.
 
-Proyek ini memakai format versi `MAJOR.MINOR.PATCH` seperti `2.2.3`.
+Proyek ini memakai format versi `MAJOR.MINOR.PATCH` seperti `2.2.4`.
 
 - Angka paling depan (`MAJOR`): perubahan besar yang biasanya membawa breaking change atau perubahan arsitektur utama.
 - Angka tengah (`MINOR`): penambahan fitur baru atau peningkatan yang tetap kompatibel dengan versi sebelumnya.

--- a/docs/correctness/README.md
+++ b/docs/correctness/README.md
@@ -40,12 +40,13 @@ npm test
 | Versi | Tanggal | Commit | Ringkasan |
 | --- | --- | --- | --- |
 | [v2.2.2](./v2.2.2.md) | 2026-04-24 | `7a0728f` + local patch | Snapshot correctness learning suite untuk recurrent dan transformer, termasuk `trimPad` |
+| [v2.2.3](./v2.2.3.md) | 2026-04-25 | `ac0806c` + local patch | Snapshot correctness setelah optimasi batching/loss/buffer pada hot path training |
 
 ## Versioning
 
-Versi aktif proyek saat ini adalah `2.2.2`.
+Versi aktif proyek saat ini adalah `2.2.3`.
 
-Proyek ini memakai format versi `MAJOR.MINOR.PATCH` seperti `2.2.2`.
+Proyek ini memakai format versi `MAJOR.MINOR.PATCH` seperti `2.2.3`.
 
 - Angka paling depan (`MAJOR`): perubahan besar yang biasanya membawa breaking change atau perubahan arsitektur utama.
 - Angka tengah (`MINOR`): penambahan fitur baru atau peningkatan yang tetap kompatibel dengan versi sebelumnya.

--- a/docs/correctness/v2.2.3.md
+++ b/docs/correctness/v2.2.3.md
@@ -1,0 +1,79 @@
+# Correctness Snapshot `v2.2.3`
+
+## Metadata
+
+- Tanggal: 25 April 2026
+- Versi: `2.2.3`
+- Commit: `ac0806c` + local patch
+- Command utama: `node -r ts-node/register test/correctness/index.ts`
+- Command suite gabungan: `npm test`
+- Status: `pass`
+
+## Cakupan
+
+Snapshot ini mencakup learning-based correctness untuk:
+
+- keluarga recurrent: `RNN`, `LSTM`, `GRU`
+- transformer `full-token`
+- transformer `full-token-trimPad`
+- transformer `next-token` legacy path
+
+Semua suite memverifikasi model tetap bisa belajar selama `10` epoch dan loss benar-benar turun.
+
+## Hasil
+
+### 1. Recurrent Learning Correctness
+
+| Family | Initial Loss | Final Loss | Improvement |
+| --- | ---: | ---: | ---: |
+| `rnn` | `0.369850` | `0.001647` | `0.368203` |
+| `lstm` | `0.408651` | `0.000754` | `0.407897` |
+| `gru` | `0.508493` | `0.001287` | `0.507205` |
+
+Interpretasi:
+
+- Ketiga keluarga recurrent tetap lolos smoke test learning 10 epoch.
+- Patch optimasi hot path tidak merusak jalur `fit(batchSize=1)` untuk model recurrent.
+
+### 2. Transformer Learning Correctness
+
+| Mode | Initial Loss | Final Loss | Improvement |
+| --- | ---: | ---: | ---: |
+| `full-token` | `2.158334` | `0.005486` | `2.152849` |
+| `full-token-trimPad` | `2.343211` | `0.007843` | `2.335368` |
+| `next-token` | `1.580817` | `0.009241` | `1.571577` |
+
+Interpretasi:
+
+- Jalur training utama `full-token` tetap belajar dengan benar setelah loss full-sequence dipindahkan untuk memakai hasil `backward()`.
+- Jalur `trimPad` juga tetap valid setelah perubahan batching dan trim window.
+- Jalur compatibility `next-token` masih benar secara learning, walau benchmark throughput-nya pada snapshot ini menunjukkan regresi performa.
+
+## Catatan Validasi
+
+- Setiap suite memverifikasi jumlah history loss tepat `10`.
+- Setiap suite memverifikasi loss finite.
+- Setiap suite memverifikasi `finalLoss < initialLoss`.
+- Setiap suite memverifikasi ada penurunan loss bermakna minimal di salah satu titik training.
+
+## Perubahan Penting
+
+- Snapshot ini menjadi companion untuk benchmark sintetis `v2.2.3`.
+- Fokus perubahan kode ada pada optimasi hot path, bukan pada perluasan cakupan correctness.
+- Hasil pass ini memastikan optimasi batching/loss/buffer tidak mengubah objective training utama.
+
+## Risiko Residual
+
+- Snapshot ini fokus pada learning regression, bukan pada kontrak shape/save-load/serialization yang lebih luas.
+- `next-token` masih lolos correctness, tetapi benchmark `v2.2.3` menunjukkan regresi throughput yang belum diatasi.
+- Untuk trim padding, snapshot correctness saat ini masih berfokus pada `right-padding`; `left-padding` belum dibekukan sebagai snapshot tersendiri.
+
+## Versioning
+
+Versi aktif proyek saat ini adalah `2.2.3`.
+
+Proyek ini memakai format versi `MAJOR.MINOR.PATCH` seperti `2.2.3`.
+
+- Angka paling depan (`MAJOR`): perubahan besar yang biasanya membawa breaking change atau perubahan arsitektur utama.
+- Angka tengah (`MINOR`): penambahan fitur baru atau peningkatan yang tetap kompatibel dengan versi sebelumnya.
+- Angka paling belakang (`PATCH`): perbaikan bug, optimasi kecil, cleanup, atau perubahan minor yang tidak mengubah API utama.

--- a/docs/correctness/v2.2.4.md
+++ b/docs/correctness/v2.2.4.md
@@ -1,0 +1,95 @@
+# Correctness Snapshot `v2.2.4`
+
+## Metadata
+
+- Tanggal: 25 April 2026
+- Versi: `2.2.4`
+- Commit: `397ed48` + local patch
+- Command utama: `node -r ts-node/register test/correctness/index.ts`
+- Command suite gabungan: `npm test`
+- Status: `pass`
+
+## Cakupan
+
+Snapshot ini mencakup:
+
+- learning-based correctness untuk keluarga recurrent: `RNN`, `LSTM`, `GRU`
+- correctness API untuk `Transformers.predictMode`
+- learning-based correctness untuk transformer `full-token`
+- learning-based correctness untuk transformer `full-token-trimPad`
+- learning-based correctness untuk transformer `next-token` legacy path
+
+Semua suite memverifikasi kontrak yang relevan tetap valid setelah perubahan ergonomi API dan refactor test.
+
+## Hasil
+
+### 1. Recurrent Learning Correctness
+
+| Family | Initial Loss | Final Loss | Improvement |
+| --- | ---: | ---: | ---: |
+| `rnn` | `0.534623` | `0.002390` | `0.532233` |
+| `lstm` | `0.409895` | `0.001536` | `0.408359` |
+| `gru` | `0.643223` | `0.001388` | `0.641835` |
+
+Interpretasi:
+
+- Ketiga keluarga recurrent tetap lolos smoke test learning 10 epoch.
+- Refactor correctness suite transformer tidak memengaruhi jalur test recurrent.
+
+### 2. Transformer API Correctness
+
+| Check | Status |
+| --- | --- |
+| `predict default next-token` | `pass` |
+| `predict full-sequence` | `pass` |
+| `set/get predictMode` | `pass` |
+| `predict restores training mode` | `pass` |
+
+Interpretasi:
+
+- `predict()` kini tervalidasi sebagai entry point inference tunggal dengan mode yang dipilih lewat constructor atau setter.
+- Mode training model tetap dipulihkan setelah `predict()`, sehingga call inference sementara tidak mengganggu loop training yang sedang aktif.
+
+### 3. Transformer Learning Correctness
+
+| Mode | Initial Loss | Final Loss | Improvement |
+| --- | ---: | ---: | ---: |
+| `full-token` | `2.343680` | `0.005813` | `2.337868` |
+| `full-token-trimPad` | `2.439620` | `0.007118` | `2.432502` |
+| `next-token` | `1.269676` | `0.010836` | `1.258840` |
+
+Interpretasi:
+
+- Jalur training utama `full-token` tetap belajar dengan benar.
+- Jalur `trimPad` tetap valid setelah perubahan API inference.
+- Jalur compatibility `next-token` juga tetap belajar, sehingga tambahan `predictMode` tidak merusak path training legacy.
+
+## Catatan Validasi
+
+- Setiap suite learning memverifikasi jumlah history loss tepat `10`.
+- Setiap suite learning memverifikasi loss finite.
+- Setiap suite learning memverifikasi `finalLoss < initialLoss`.
+- Setiap suite learning memverifikasi ada penurunan loss bermakna minimal di salah satu titik training.
+- Suite API memverifikasi shape output dan perilaku restore mode pada `predict()`.
+
+## Perubahan Penting
+
+- Snapshot ini menjadi companion untuk benchmark sintetis `v2.2.4`.
+- Correctness transformer kini dipisah menjadi dua area: kontrak API dan learning behavior.
+- Penambahan `predictMode` kini dibekukan sebagai kontrak perilaku yang diuji eksplisit.
+
+## Risiko Residual
+
+- Snapshot ini fokus pada learning regression dan kontrak inference API, bukan pada save/load atau serialisasi state `predictMode`.
+- Belum ada benchmark khusus untuk membandingkan biaya inference antara `predictMode="next-token"` dan `predictMode="full-sequence"`.
+- Left-padding correctness masih belum dibekukan sebagai snapshot tersendiri.
+
+## Versioning
+
+Versi aktif proyek saat ini adalah `2.2.4`.
+
+Proyek ini memakai format versi `MAJOR.MINOR.PATCH` seperti `2.2.4`.
+
+- Angka paling depan (`MAJOR`): perubahan besar yang biasanya membawa breaking change atau perubahan arsitektur utama.
+- Angka tengah (`MINOR`): penambahan fitur baru atau peningkatan yang tetap kompatibel dengan versi sebelumnya.
+- Angka paling belakang (`PATCH`): perbaikan bug, optimasi kecil, cleanup, atau perubahan minor yang tidak mengubah API utama.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ml-v1",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ml-v1",
-      "version": "2.2.3",
+      "version": "2.2.4",
       "license": "ISC",
       "dependencies": {
         "@napi-rs/wasm-runtime": "^0.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ml-v1",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ml-v1",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "ISC",
       "dependencies": {
         "@napi-rs/wasm-runtime": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ml-v1",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "napi": {
     "name": "ml-native"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ml-v1",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "napi": {
     "name": "ml-native"
   },

--- a/src/layers/embedding.ts
+++ b/src/layers/embedding.ts
@@ -209,6 +209,7 @@ export default class Embedding {
       }
     }
     this.inputIndices = this.orderedInputBuffer;
+    this.validateTokenIndices(totalTokens);
 
     const seqLen = totalTokens;
     this.inputShape = [rows, cols];
@@ -230,9 +231,6 @@ export default class Embedding {
 
     for (let j = 0; j < seqLen; j++) {
       const tokenIndex = Math.floor(this.inputIndices[j]);
-      if (tokenIndex < 0 || tokenIndex >= this.vocabSize) {
-        throw new Error(`Token index '${tokenIndex}' di luar kapasitas vocabulary (0 - ${this.vocabSize - 1})`);
-      }
       if (this.padTokenId !== null && tokenIndex === this.padTokenId) {
         continue;
       }
@@ -242,5 +240,15 @@ export default class Embedding {
     }
 
     return this.outputBuffer;
+  }
+
+  private validateTokenIndices(seqLen: number): void {
+    for (let j = 0; j < seqLen; j++) {
+      const rawTokenIndex = this.inputIndices[j];
+      const tokenIndex = Math.floor(rawTokenIndex);
+      if (!Number.isFinite(rawTokenIndex) || tokenIndex < 0 || tokenIndex >= this.vocabSize) {
+        throw new Error(`Token index '${rawTokenIndex}' di luar kapasitas vocabulary (0 - ${this.vocabSize - 1})`);
+      }
+    }
   }
 }

--- a/src/layers/multiHeadAttention.ts
+++ b/src/layers/multiHeadAttention.ts
@@ -123,13 +123,14 @@ export default class MultiHeadAttention {
 
   compile({ alpha, optimizer, error, clipGradient }: { alpha?: number; optimizer?: Optimzier; error?: Cost; clipGradient?: number | boolean }) {
     if (alpha !== undefined) this.alpha = alpha;
+    if (clipGradient !== undefined) this.clipGradient = clipGradient;
     if (optimizer !== undefined) {
       this.optimizerName = optimizer;
       this.optimizerQ = setOptimizer(optimizer, this.q._shape, this.alpha);
       this.optimizerK = setOptimizer(optimizer, this.k._shape, this.alpha);
       this.optimizerV = setOptimizer(optimizer, this.v._shape, this.alpha);
     }
-    this.wo.compile({ alpha, optimizer, error });
+    this.wo.compile({ alpha, optimizer, error, clipGradient });
   }
 
   setPadMask(padMask: boolean[]): void {

--- a/src/layers/multiHeadAttention.ts
+++ b/src/layers/multiHeadAttention.ts
@@ -48,12 +48,21 @@ export default class MultiHeadAttention {
   private K: Matrix;
   private V: Matrix;
   private concatenated: Matrix;
+  private qBuffer: Float32Array = new Float32Array(0);
+  private kBuffer: Float32Array = new Float32Array(0);
+  private vBuffer: Float32Array = new Float32Array(0);
+  private concatenatedBuffer: Float32Array = new Float32Array(0);
 
   private gradInputBuffer: Matrix;
   private gradContributionBuffer: Matrix;
   private dQAll: Matrix;
   private dKAll: Matrix;
   private dVAll: Matrix;
+  private gradInputDataBuffer: Float32Array = new Float32Array(0);
+  private gradContributionDataBuffer: Float32Array = new Float32Array(0);
+  private dQAllBuffer: Float32Array = new Float32Array(0);
+  private dKAllBuffer: Float32Array = new Float32Array(0);
+  private dVAllBuffer: Float32Array = new Float32Array(0);
 
   private gradQBuffer: Matrix;
   private gradKBuffer: Matrix;
@@ -337,17 +346,16 @@ export default class MultiHeadAttention {
 
     this.inputShape = [this.units, totalCols];
     this.outputShape = [this.units, totalCols];
+    this.Q = this.bindSequenceMatrix("qBuffer", totalCols);
+    this.K = this.bindSequenceMatrix("kBuffer", totalCols);
+    this.V = this.bindSequenceMatrix("vBuffer", totalCols);
+    this.concatenated = this.bindSequenceMatrix("concatenatedBuffer", totalCols);
 
-    this.Q = mj.zeros([this.units, totalCols]);
-    this.K = mj.zeros([this.units, totalCols]);
-    this.V = mj.zeros([this.units, totalCols]);
-    this.concatenated = mj.zeros([this.units, totalCols]);
-
-    this.gradInputBuffer = mj.zeros([this.units, totalCols]);
-    this.gradContributionBuffer = mj.zeros([this.units, totalCols]);
-    this.dQAll = mj.zeros([this.units, totalCols]);
-    this.dKAll = mj.zeros([this.units, totalCols]);
-    this.dVAll = mj.zeros([this.units, totalCols]);
+    this.gradInputBuffer = this.bindSequenceMatrix("gradInputDataBuffer", totalCols);
+    this.gradContributionBuffer = this.bindSequenceMatrix("gradContributionDataBuffer", totalCols);
+    this.dQAll = this.bindSequenceMatrix("dQAllBuffer", totalCols);
+    this.dKAll = this.bindSequenceMatrix("dKAllBuffer", totalCols);
+    this.dVAll = this.bindSequenceMatrix("dVAllBuffer", totalCols);
 
     if (this.attentionBuffer.length < expectedAttentionLen) {
       const nextCapacity = Math.max(expectedAttentionLen, Math.max(1, this.attentionBuffer.length * 2));
@@ -366,6 +374,31 @@ export default class MultiHeadAttention {
       this.errScoreBuffer = new Float32Array(nextCapacity);
     }
     this.errScoreScratch = this.errScoreBuffer.subarray(0, expectedScratchLen);
+  }
+
+  private bindSequenceMatrix(
+    bufferKey:
+      | "qBuffer"
+      | "kBuffer"
+      | "vBuffer"
+      | "concatenatedBuffer"
+      | "gradInputDataBuffer"
+      | "gradContributionDataBuffer"
+      | "dQAllBuffer"
+      | "dKAllBuffer"
+      | "dVAllBuffer",
+    totalCols: number
+  ): Matrix {
+    const requiredLength = this.units * totalCols;
+    let buffer = this[bufferKey];
+
+    if (buffer.length < requiredLength) {
+      const nextCapacity = Math.max(requiredLength, Math.max(1, buffer.length * 2));
+      buffer = new Float32Array(nextCapacity);
+      this[bufferKey] = buffer;
+    }
+
+    return Matrix.fromFlat(buffer.subarray(0, requiredLength), [this.units, totalCols]);
   }
 
   private loadLegacyHeads(headsData: Array<{ q: number[][]; k: number[][]; v: number[][] }>) {

--- a/src/layers/positionalEncoding.ts
+++ b/src/layers/positionalEncoding.ts
@@ -80,8 +80,9 @@ export default class PositionalEncoding {
    *   retain their original absolute positions in the PE table.
    * @param seqLen - actual per-batch sequence length used for cycling column indices to
    *   positions within a sequence.  Defaults to maxSeqLen (original behavior).
+   * @param padMask - optional sample-major mask where true means the whole token column is PAD.
    */
-  forward(x: Matrix, positionOffset = 0, seqLen?: number): Matrix {
+  forward(x: Matrix, positionOffset = 0, seqLen?: number, padMask?: boolean[]): Matrix {
     const actualTotalTokens = x._shape[1];
     const cycleLen = seqLen ?? this.maxSeqLen;
     this.inputShape = [this.dModel, actualTotalTokens];
@@ -113,7 +114,7 @@ export default class PositionalEncoding {
           );
         }
         const val = xData[xOffset + j];
-        result[outOffset + j] = val === 0 ? 0 : val + peData[peOffset + absolutePos];
+        result[outOffset + j] = padMask?.[j] === true ? 0 : val + peData[peOffset + absolutePos];
       }
     }
 

--- a/src/layers/positionalEncoding.ts
+++ b/src/layers/positionalEncoding.ts
@@ -27,6 +27,7 @@ export default class PositionalEncoding {
   // Tabel PE yang sudah diprecompute: [dModel, maxSeqLen]
   private peTable: Matrix;
   private resultBuffer: Matrix | null = null;
+  private inferredPadMask: boolean[] = [];
 
   constructor({
     dModel,
@@ -99,6 +100,7 @@ export default class PositionalEncoding {
     const xData = x._data;
     const peData = this.peTable._data;
     const peCols = this.peTable._shape[1];
+    const effectivePadMask = padMask ?? this.inferPadColumns(x);
 
     for (let i = 0; i < this.dModel; i++) {
       const xOffset = i * cols;
@@ -114,7 +116,7 @@ export default class PositionalEncoding {
           );
         }
         const val = xData[xOffset + j];
-        result[outOffset + j] = padMask?.[j] === true ? 0 : val + peData[peOffset + absolutePos];
+        result[outOffset + j] = effectivePadMask[j] ? 0 : val + peData[peOffset + absolutePos];
       }
     }
 
@@ -130,5 +132,25 @@ export default class PositionalEncoding {
 
   resetLoss(): void {
     this.loss = 0;
+  }
+
+  private inferPadColumns(x: Matrix): boolean[] {
+    const [rows, cols] = x._shape;
+    if (this.inferredPadMask.length !== cols) {
+      this.inferredPadMask = new Array<boolean>(cols);
+    }
+    this.inferredPadMask.fill(true);
+
+    const data = x._data;
+    for (let j = 0; j < cols; j++) {
+      for (let i = 0; i < rows; i++) {
+        if (data[i * cols + j] !== 0) {
+          this.inferredPadMask[j] = false;
+          break;
+        }
+      }
+    }
+
+    return this.inferredPadMask;
   }
 }

--- a/src/models/sequential.ts
+++ b/src/models/sequential.ts
@@ -12,6 +12,8 @@ export default class Sequential {
   layers: SequentialLayers;
   loss = 0;
   protected isTrainingMode = true;
+  private batchInputBufferData: Float32Array = new Float32Array(0);
+  private batchTargetBufferData: Float32Array = new Float32Array(0);
   constructor({ layers = [] }: { layers?: SequentialLayers } = {}) {
     this.layers = layers;
   }
@@ -208,25 +210,6 @@ export default class Sequential {
 
         let currentBatchX: Matrix;
         let currentBatchY: Matrix;
-
-        if (currentBatchSize === 1) {
-          const idx = trainIndices[start];
-          currentBatchX = trainX[idx];
-          currentBatchY = trainY[idx];
-        } else {
-          // Buat batch matrix [rows, currentBatchSize]
-          const [rowsX] = trainX[0]._shape;
-          const [rowsY] = trainY[0]._shape;
-          currentBatchX = mj.zeros([rowsX, currentBatchSize]);
-          currentBatchY = mj.zeros([rowsY, currentBatchSize]);
-
-          for (let j = 0; j < currentBatchSize; j++) {
-            const idx = trainIndices[start + j];
-            currentBatchX.setCol(j, trainX[idx]._data);
-            currentBatchY.setCol(j, trainY[idx]._data);
-          }
-        }
-
         const modelAny = this as any;
         const padIdRaw: number | null | undefined =
           typeof modelAny.getPadTokenId === "function" ? modelAny.getPadTokenId() : null;
@@ -234,19 +217,57 @@ export default class Sequential {
           trimPadding &&
           padIdRaw !== null &&
           padIdRaw !== undefined &&
-          currentBatchX._shape[0] === currentBatchY._shape[0] &&
+          trainX[0]._shape[0] === trainY[0]._shape[0] &&
           typeof modelAny.setPositionOffset === "function";
+        let positionOffset = 0;
+
+        if (currentBatchSize === 1) {
+          const idx = trainIndices[start];
+          currentBatchX = trainX[idx];
+          currentBatchY = trainY[idx];
+
+          if (supportsTrimPadding) {
+            const trimResult = trimPaddingBatch(currentBatchX, currentBatchY, padIdRaw as number, paddingSide);
+            currentBatchX = trimResult.x;
+            currentBatchY = trimResult.y;
+            positionOffset = trimResult.positionOffset;
+          }
+        } else {
+          const trimWindow = supportsTrimPadding
+            ? this.computeBatchTrimWindow(trainX, trainY, trainIndices, start, currentBatchSize, padIdRaw as number, paddingSide)
+            : null;
+          const batchStartRow = trimWindow?.startRow ?? 0;
+          const [rowsX] = trainX[0]._shape;
+          const [rowsY] = trainY[0]._shape;
+          const effectiveRowsX = trimWindow?.rowCount ?? rowsX;
+          const effectiveRowsY = trimWindow?.rowCount ?? rowsY;
+          currentBatchX = this.createReusableBatchMatrix("x", effectiveRowsX, currentBatchSize);
+          currentBatchY = this.createReusableBatchMatrix("y", effectiveRowsY, currentBatchSize);
+          positionOffset = trimWindow?.positionOffset ?? 0;
+
+          for (let j = 0; j < currentBatchSize; j++) {
+            const idx = trainIndices[start + j];
+            const sourceX = trainX[idx]._data;
+            const sourceY = trainY[idx]._data;
+            if (batchStartRow === 0 && effectiveRowsX === rowsX) {
+              currentBatchX.setCol(j, sourceX);
+              currentBatchY.setCol(j, sourceY);
+            } else {
+              currentBatchX.setCol(j, sourceX.subarray(batchStartRow, batchStartRow + effectiveRowsX));
+              currentBatchY.setCol(j, sourceY.subarray(batchStartRow, batchStartRow + effectiveRowsY));
+            }
+          }
+        }
 
         if (supportsTrimPadding) {
-          const trimResult = trimPaddingBatch(currentBatchX, currentBatchY, padIdRaw as number, paddingSide);
-          currentBatchX = trimResult.x;
-          currentBatchY = trimResult.y;
-          modelAny.setPositionOffset(trimResult.positionOffset);
+          modelAny.setPositionOffset(positionOffset);
         }
 
         const pred = this.forward(currentBatchX);
-        const batchLossValue = this.computeSampleLoss(currentBatchY, pred);
         this.backward(currentBatchY);
+        const batchLossValue = this.useBackwardLossForTrainingBatch(currentBatchY, pred)
+          ? this.loss
+          : this.computeSampleLoss(currentBatchY, pred);
 
         if (supportsTrimPadding && typeof modelAny.resetPositionOffset === "function") {
           modelAny.resetPositionOffset();
@@ -424,6 +445,10 @@ export default class Sequential {
     return loss;
   }
 
+  protected useBackwardLossForTrainingBatch(_yTrue: Matrix, _yPred: Matrix): boolean {
+    return false;
+  }
+
   private assertRecurrentFitSupported(
     X: Matrix[],
     batchSize: number,
@@ -465,5 +490,78 @@ export default class Sequential {
 
   private isRecurrentLayer(layer: SequentialLayers[number]): boolean {
     return layer.name === "rnn layer" || layer.name === "lstm layer" || layer.name === "gru layer";
+  }
+
+  private createReusableBatchMatrix(kind: "x" | "y", rows: number, cols: number): Matrix {
+    const requiredLength = rows * cols;
+    const currentBuffer = kind === "x" ? this.batchInputBufferData : this.batchTargetBufferData;
+    let nextBuffer = currentBuffer;
+
+    if (nextBuffer.length < requiredLength) {
+      const nextCapacity = Math.max(requiredLength, Math.max(1, nextBuffer.length * 2));
+      nextBuffer = new Float32Array(nextCapacity);
+      if (kind === "x") {
+        this.batchInputBufferData = nextBuffer;
+      } else {
+        this.batchTargetBufferData = nextBuffer;
+      }
+    }
+
+    return Matrix.fromFlat(nextBuffer.subarray(0, requiredLength), [rows, cols]);
+  }
+
+  private computeBatchTrimWindow(
+    X: Matrix[],
+    y: Matrix[],
+    indices: number[],
+    start: number,
+    currentBatchSize: number,
+    padId: number,
+    paddingSide: "left" | "right"
+  ): { startRow: number; rowCount: number; positionOffset: number } {
+    const seqLen = X[0]._shape[0];
+
+    if (paddingSide === "right") {
+      let lastUsefulPos = -1;
+      for (let j = 0; j < currentBatchSize; j++) {
+        const idx = indices[start + j];
+        const xData = X[idx]._data;
+        const yData = y[idx]._data;
+        for (let pos = 0; pos < seqLen; pos++) {
+          if (xData[pos] !== padId || yData[pos] !== padId) {
+            lastUsefulPos = Math.max(lastUsefulPos, pos);
+          }
+        }
+      }
+
+      if (lastUsefulPos < 0 || lastUsefulPos + 1 >= seqLen) {
+        return { startRow: 0, rowCount: seqLen, positionOffset: 0 };
+      }
+
+      return { startRow: 0, rowCount: lastUsefulPos + 1, positionOffset: 0 };
+    }
+
+    let firstUsefulPos = seqLen;
+    for (let j = 0; j < currentBatchSize; j++) {
+      const idx = indices[start + j];
+      const xData = X[idx]._data;
+      const yData = y[idx]._data;
+      for (let pos = 0; pos < seqLen; pos++) {
+        if (xData[pos] !== padId || yData[pos] !== padId) {
+          firstUsefulPos = Math.min(firstUsefulPos, pos);
+          break;
+        }
+      }
+    }
+
+    if (firstUsefulPos <= 0 || firstUsefulPos >= seqLen) {
+      return { startRow: 0, rowCount: seqLen, positionOffset: 0 };
+    }
+
+    return {
+      startRow: firstUsefulPos,
+      rowCount: seqLen - firstUsefulPos,
+      positionOffset: firstUsefulPos,
+    };
   }
 }

--- a/src/models/sequential.ts
+++ b/src/models/sequential.ts
@@ -360,7 +360,13 @@ export default class Sequential {
         modelAny.setPositionOffset(trimResult.positionOffset);
       }
 
-      const pred = this.forward(valBatchX);
+      const shouldUseFullSequenceForward =
+        valBatchY._shape[0] === valBatchX._shape[0] &&
+        valBatchY._shape[1] === valBatchX._shape[1] &&
+        typeof modelAny.forwardFullSequence === "function";
+      const pred = shouldUseFullSequenceForward
+        ? modelAny.forwardFullSequence(valBatchX)
+        : this.forward(valBatchX);
       totalValLoss += this.computeSampleLoss(valBatchY, pred);
 
       if (supportsTrimPadding && typeof modelAny.resetPositionOffset === "function") {

--- a/src/models/transformers.ts
+++ b/src/models/transformers.ts
@@ -7,6 +7,8 @@ import { MultiHeadAttention, Dense, PositionalEncoding, LayerNormalization, Embe
 import { FitConfig, FitResult } from "../@types/fitConfig";
 import { isNativeAvailable, maskedSparseSoftmaxCrossEntropyNative } from "../math/rust_backend";
 
+export type TransformersPredictMode = "next-token" | "full-sequence";
+
 interface TransformersConfig {
   units: number;          // d_model (embedding size)
   seqLen: number;         // sequence length
@@ -17,6 +19,7 @@ interface TransformersConfig {
   alpha?: number;         // learning rate
   padTokenId?: number;
   clipGradient?: number | boolean;
+  predictMode?: TransformersPredictMode;
 }
 
 interface TransformerBlock {
@@ -70,6 +73,7 @@ export default class Transformers extends Sequential {
   private profilerEnabled: boolean = false;
   private profileStats: { [key: string]: { totalMs: number; count: number } } = Object.create(null);
   private positionOffset: number = 0;
+  private predictMode: TransformersPredictMode;
 
   constructor({
     units,
@@ -80,10 +84,14 @@ export default class Transformers extends Sequential {
     dropoutRate = 0.1,
     alpha = 0.01,
     padTokenId,
-    clipGradient = 5.0
+    clipGradient = 5.0,
+    predictMode = "next-token",
   }: TransformersConfig) {
     if (!Number.isInteger(numBlocks) || numBlocks < 1) {
       throw new Error(`Transformers: numBlocks harus integer >= 1, got ${numBlocks}`);
+    }
+    if (predictMode !== "next-token" && predictMode !== "full-sequence") {
+      throw new Error(`Transformers: predictMode harus "next-token" atau "full-sequence", got ${predictMode}`);
     }
 
     const embedding = new Embedding({ vocabSize, embeddingDim: units, alpha, padTokenId });
@@ -147,6 +155,7 @@ export default class Transformers extends Sequential {
     this.ffn2 = blocks[0].ffn2;
     this.drop2 = blocks[0].drop2;
     this.dense = dense;
+    this.predictMode = predictMode;
 
     // Pre-allocate buffers
     this.lastTokenBuffer = mj.zeros([units, 1]);
@@ -192,9 +201,23 @@ export default class Transformers extends Sequential {
   predict(x: Matrix): Matrix {
     const wasTraining = this.isTrainingMode;
     this.eval();
-    const out = this.forwardNextToken(x);
+    const out = this.predictMode === "full-sequence"
+      ? this.forwardFullSequence(x)
+      : this.forwardNextToken(x);
     if (wasTraining) this.train();
     return out;
+  }
+
+  setPredictMode(mode: TransformersPredictMode): this {
+    if (mode !== "next-token" && mode !== "full-sequence") {
+      throw new Error(`Transformers.setPredictMode: mode harus "next-token" atau "full-sequence", got ${mode}`);
+    }
+    this.predictMode = mode;
+    return this;
+  }
+
+  getPredictMode(): TransformersPredictMode {
+    return this.predictMode;
   }
 
   backward(y: Matrix) {

--- a/src/models/transformers.ts
+++ b/src/models/transformers.ts
@@ -501,6 +501,17 @@ export default class Transformers extends Sequential {
     return totalLoss / validTokens;
   }
 
+  protected useBackwardLossForTrainingBatch(yTrue: Matrix, yPred: Matrix): boolean {
+    const seqLen = this.lastInputTokens._shape[0];
+    const batchSize = this.lastInputTokens._shape[1];
+    return (
+      yTrue._shape[0] === seqLen &&
+      yTrue._shape[1] === batchSize &&
+      yPred._shape[0] === this.vocabSize &&
+      yPred._shape[1] === seqLen * batchSize
+    );
+  }
+
   load(path: string) {
     const dataJson = readFileSync(path, "utf-8");
     const data = JSON.parse(dataJson);

--- a/src/optimizer/adaGrad.ts
+++ b/src/optimizer/adaGrad.ts
@@ -6,20 +6,26 @@ export default class AdaGrad {
   shape: MatrixShape;
   sumGradien: Matrix;
   epsilon: number = 0.1;
+  private updateBuffer: Matrix;
   constructor(shape: MatrixShape, epsilon: number) {
     this.shape = shape;
     this.sumGradien = mj.zeros(this.shape);
+    this.updateBuffer = mj.zeros(this.shape);
     this.epsilon = epsilon;
   }
 
   calculate(a: Matrix, alpha: number) {
-    // AdaGrad: G_t = G_{t-1} + g_t²  (akumulasi kuadrat gradient)
-    const squaredGradient = mj.map(a, (val) => val ** 2);
-    const sumGradien = mj.add(this.sumGradien, squaredGradient);
-    const addEpsilon = mj.add(sumGradien, this.epsilon);
-    const sqrtGradien = mj.map(addEpsilon, (val) => Math.sqrt(val));
-    const newAlpha = mj.div(alpha, sqrtGradien);
-    this.sumGradien = sumGradien;
-    return mj.mul(newAlpha, a);
+    const gradData = a._data;
+    const sumData = this.sumGradien._data;
+    const updateData = this.updateBuffer._data;
+
+    for (let i = 0; i < gradData.length; i++) {
+      const grad = gradData[i];
+      const accumulated = sumData[i] + grad * grad;
+      sumData[i] = accumulated;
+      updateData[i] = alpha * grad / Math.sqrt(accumulated + this.epsilon);
+    }
+
+    return this.updateBuffer;
   }
 }

--- a/test/correctness/index.ts
+++ b/test/correctness/index.ts
@@ -1,8 +1,10 @@
 import { runRecurrentLearningCorrectnessSuite } from "./rnn.learning.test";
+import { runTransformerApiCorrectnessSuite } from "./transformers.api.test";
 import { runTransformerLearningCorrectnessSuite } from "./transformers.learning.test";
 
 export function runCorrectnessSuite(): void {
   runRecurrentLearningCorrectnessSuite();
+  runTransformerApiCorrectnessSuite();
   runTransformerLearningCorrectnessSuite();
 }
 

--- a/test/correctness/transformers.api.test.ts
+++ b/test/correctness/transformers.api.test.ts
@@ -1,0 +1,83 @@
+import mj from "../../src/math";
+import Matrix from "../../src/matrix";
+import { Transformers } from "../../src/models";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function buildSequenceMatrix(tokens: number[]): Matrix {
+  return mj.matrix(tokens.map((token) => [token]));
+}
+
+function createTransformerModel(predictMode: "next-token" | "full-sequence" = "next-token"): Transformers {
+  return new Transformers({
+    units: 24,
+    seqLen: 6,
+    vocabSize: 16,
+    heads: 4,
+    numBlocks: 1,
+    dropoutRate: 0,
+    alpha: 0.01,
+    padTokenId: 0,
+    predictMode,
+  });
+}
+
+export function runTransformerApiCorrectnessSuite(): void {
+  const x = buildSequenceMatrix([1, 2, 3, 4, 5, 6]);
+
+  const nextTokenModel = createTransformerModel();
+  const nextTokenPred = nextTokenModel.predict(x);
+  assert(
+    nextTokenPred._shape[0] === 16 && nextTokenPred._shape[1] === 1,
+    `transformers predict(next-token): expected [16,1], got [${nextTokenPred._shape[0]}, ${nextTokenPred._shape[1]}]`
+  );
+  assert(
+    nextTokenModel.getPredictMode() === "next-token",
+    `transformers predict(next-token): expected mode next-token, got ${nextTokenModel.getPredictMode()}`
+  );
+
+  const fullSequenceModel = createTransformerModel("full-sequence");
+  const fullSequencePred = fullSequenceModel.predict(x);
+  assert(
+    fullSequencePred._shape[0] === 16 && fullSequencePred._shape[1] === 6,
+    `transformers predict(full-sequence): expected [16,6], got [${fullSequencePred._shape[0]}, ${fullSequencePred._shape[1]}]`
+  );
+  assert(
+    fullSequenceModel.getPredictMode() === "full-sequence",
+    `transformers predict(full-sequence): expected mode full-sequence, got ${fullSequenceModel.getPredictMode()}`
+  );
+
+  fullSequenceModel.train();
+  const predWhileTraining = fullSequenceModel.predict(x);
+  assert(
+    predWhileTraining._shape[0] === 16 && predWhileTraining._shape[1] === 6,
+    `transformers predict(full-sequence while training): expected [16,6], got [${predWhileTraining._shape[0]}, ${predWhileTraining._shape[1]}]`
+  );
+  const forwardAfterPredict = fullSequenceModel.forward(x);
+  assert(
+    forwardAfterPredict._shape[0] === 16 && forwardAfterPredict._shape[1] === 6,
+    `transformers predict(full-sequence while training): expected training mode restored so forward() returns [16,6], got [${forwardAfterPredict._shape[0]}, ${forwardAfterPredict._shape[1]}]`
+  );
+  assert(
+    fullSequenceModel.getPredictMode() === "full-sequence",
+    `transformers predict(full-sequence while training): expected mode full-sequence after predict, got ${fullSequenceModel.getPredictMode()}`
+  );
+
+  const switchedPred = fullSequenceModel.setPredictMode("next-token").predict(x);
+  assert(
+    switchedPred._shape[0] === 16 && switchedPred._shape[1] === 1,
+    `transformers setPredictMode(next-token): expected [16,1], got [${switchedPred._shape[0]}, ${switchedPred._shape[1]}]`
+  );
+
+  console.log("=== Transformer API Correctness ===");
+  console.table([
+    { check: "predict default next-token", status: "pass" },
+    { check: "predict full-sequence", status: "pass" },
+    { check: "set/get predictMode", status: "pass" },
+    { check: "predict restores training mode", status: "pass" },
+  ]);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v2.2.4

* **New Features**
  * Transformers now support configurable `predictMode` ("next-token" or "full-sequence") to control inference behavior
  * Added `setPredictMode()` and `getPredictMode()` methods for runtime mode switching
  * `predict()` is now the primary inference entry point with output shapes determined by `predictMode`

* **Documentation**
  * Updated Transformers inference guidance with `predictMode` configuration examples
  * Added best practices for switching between prediction modes

* **Tests**
  * Added transformer API correctness test suite

* **Chores**
  * Version bumped to 2.2.4
  * Added v2.2.3 and v2.2.4 benchmark and correctness snapshots

<!-- end of auto-generated comment: release notes by coderabbit.ai -->